### PR TITLE
Asynchronous classification solutions & errors in the legend fixed

### DIFF
--- a/interface/commandbar_cb.m
+++ b/interface/commandbar_cb.m
@@ -568,6 +568,8 @@ if ~isempty(curve)&~isempty(shapes)%&curve{1}(1,1)~=0&shapes{1}(1,1)~=0
             %                  case 'Robust Solver',watchon;,[curve,shapes]=strip(prop,node,elem,lengths,1,springs,constraints);,watchoff;,end,
             %watchon;,[curve,shapes]=stripmain(prop,node,elem,lengths,springs,constraints,GBTcon,BC,m_all,neigs);,watchoff;
             [curve,shapes]=stripmain(prop,node,elem,lengths,springs,constraints,GBTcon,BC,m_all,neigs);
+			clascell={};
+			clas=[];
             compareout(1);
     end
 elseif ~isempty(prop)&~isempty(node)&~isempty(elem)&~isempty(lengths)&~isempty(BC)&~isempty(m_all)
@@ -576,6 +578,8 @@ elseif ~isempty(prop)&~isempty(node)&~isempty(elem)&~isempty(lengths)&~isempty(B
     %				   case 'Robust Solver',watchon;,[curve,shapes]=strip(prop,node,elem,lengths,1,springs,constraints);,watchoff;,end,
     %watchon;,[curve,shapes]=stripmain(prop,node,elem,lengths,springs,constraints,GBTcon,BC,m_all,neigs);,watchoff;
     [curve,shapes]=stripmain(prop,node,elem,lengths,springs,constraints,GBTcon,BC,m_all,neigs);
+	clascell={};
+	clas=[];
     compareout(1);
 else
     if screen==2

--- a/interface/compareout_cb.m
+++ b/interface/compareout_cb.m
@@ -734,6 +734,7 @@ elseif cFSM_analysis==1
     else        
         %perform the classification
         wait_message=waitbar(0,'Performing Modal Classification');
+		clas={};%clear the previous classification solution
         %generate unit length natural base vectors
         
         %loop over the length

--- a/plotters/thecurve3.m
+++ b/plotters/thecurve3.m
@@ -18,6 +18,7 @@ marker=['.x+*sdv^<'];
 %fileindex=1;
 %modeindex=1;
 %If the classification option is on, then start with modal classification
+clasLgd=[];
 if clasopt
     clas=clascell{fileindex};
 %     solutiontype=solutiontypecell{fileindex};
@@ -36,7 +37,7 @@ if clasopt
             hold on
             if length(curve_length)>=2
                 hc=area(curve_length,clasplot);
-                legend(hc,'global','distortional','local','other','Location','best')
+                clasLgd=legend(hc,'global','distortional','local','other','Location','best','AutoUpdate','Off');
             else
                 if logopt==1
                     semilogx(curve_length,clasplot(1),'c.','MarkerSize',20);...
@@ -49,7 +50,7 @@ if clasopt
                     plot(curve_length,clasplot(3),'m.','MarkerSize',20);
                     plot(curve_length,clasplot(4),'b.','MarkerSize',20);
                 end
-                legend('global','distortional','local','other','Location','best')
+                clasLgd=legend('global','distortional','local','other','Location','best','AutoUpdate','Off');
             end
             
             axis([xmin xmax ymin ymax])
@@ -167,6 +168,8 @@ end %loop on different files
 
 hold off
 
+% Another way is maintaining a list of all the object handles (and a cell of the labels) to be shown in the legend, and build the legend at last. 
+
 %Add a legend
 if clasopt
 %     solutiontype=solutiontypecell{fileindex};
@@ -174,7 +177,9 @@ if clasopt
 %        h=legend(hndlmark,filenamecell{filedisplay});
 %     end
     %   	legend(hc,'global','distortional','local','other')
-	legend(hc,'global','distortional','local','other','Location','best','AutoUpdate','Off')
+	if isempty(clasLgd)
+		legend(hndlmark,filenamecell{filedisplay},'Location','best','AutoUpdate','Off');
+	end
 else
     h=legend(hndlmark,filenamecell{filedisplay},'Location','best','AutoUpdate','Off');
     %don't use latex in the legend so underscores are written ok

--- a/plotters/thecurve3mode.m
+++ b/plotters/thecurve3mode.m
@@ -16,7 +16,7 @@ marker=['.x+*sdv^<>'];
 %
 
 % hold off
-
+clasLgd=[];
 %If the classification option is on, then start with modal classification
 if clasopt
     clas=clascell{fileindex};
@@ -32,8 +32,7 @@ if clasopt
 %         end
         hold on
         hc=bar([1:length(curve{lengthindex}(:,2))],clasplot,1,'stacked');
-        hlegend=legend(hc,'global','distortional','local','other');
-        set(hlegend,'Location','best');
+        clasLgd=legend(hc,'global','distortional','local','other','Location','best','AutoUpdate','Off');
 %         axis tight
         colormap(axesnum,lines(4));
         axis([xmin xmax ymin ymax])
@@ -76,7 +75,9 @@ hold off
 %Add a legend
 if clasopt
     %   	legend(hc,'global','distortional','local','other')
-	legend(hc,'global','distortional','local','other','Location','best','AutoUpdate','Off')
+	if isempty(clasLgd)
+		legend(hndlmark,filenamecell{filedisplay},'Location','best','AutoUpdate','Off');
+	end
 else
 %     h=legend(hndlmark,legendname{[1:filenumbers-1]});
 %     set(h,'Location','best');


### PR DESCRIPTION
1. Each time right after a call to function ”stripmain“, the modal classification solutions (variables "clascell" and "clas") are cleared, because they belong to previous buckling solution, not the current. Now every operation corresponding to the modal classification solution conforms to logic.
2. The previous fix to the legends in the functions "thecurve3" and "thecurve3mode" is not enough, Sometimes errors may occur. They are fixed again. Now everything is OK. It should be better If maintaining a list of all the object handles (and a cell of the labels) to be shown in the legend, and build the legend at last.