### PR TITLE
3D plotter improvements/bug fixes

### DIFF
--- a/interface/boundcond.m
+++ b/interface/boundcond.m
@@ -450,7 +450,7 @@ for i=1:length(HPm_all{lengthindex})
     elseif strcmp(HPBC,'S-C')|strcmp(HPBC,'C-S')
         y_shapes(i,:)=sin((HPm_all{lengthindex}(i)+1)*pi*x_length/HPlengths(lengthindex))+(HPm_all{lengthindex}(i)+1)*sin(HPm_all{lengthindex}(i)*pi*x_length/HPlengths(lengthindex))/HPm_all{lengthindex}(i);
     elseif strcmp(HPBC,'C-F')|strcmp(HPBC,'F-C')
-        y_shapes(i,:)=1-cos((HPm_all{lengthindex}(i)-0.5)*x_length/HPlengths(lengthindex));
+        y_shapes(i,:)=1-cos((HPm_all{lengthindex}(i)-0.5)*pi*x_length/HPlengths(lengthindex));
     elseif strcmp(HPBC,'C-G')|strcmp(HPBC,'G-C')
         y_shapes(i,:)=sin((HPm_all{lengthindex}(i)-0.5)*pi*x_length/HPlengths(lengthindex)).*sin(pi*x_length/HPlengths(lengthindex)/2);
     end

--- a/interface/boundcond_cb.m
+++ b/interface/boundcond_cb.m
@@ -331,7 +331,7 @@ switch num
             elseif strcmp(HPBC,'S-C')|strcmp(HPBC,'C-S')
                 y_shapes(i,:)=sin((HPm_all{lengthindex}(i)+1)*pi*x_length/HPlengths(lengthindex))+(HPm_all{lengthindex}(i)+1)*sin(HPm_all{lengthindex}(i)*pi*x_length/HPlengths(lengthindex))/HPm_all{lengthindex}(i);
             elseif strcmp(HPBC,'C-F')|strcmp(HPBC,'F-C')
-                y_shapes(i,:)=1-cos((HPm_all{lengthindex}(i)-0.5)*x_length/HPlengths(lengthindex));
+                y_shapes(i,:)=1-cos((HPm_all{lengthindex}(i)-0.5)*pi*x_length/HPlengths(lengthindex));
             elseif strcmp(HPBC,'C-G')|strcmp(HPBC,'G-C')
                 y_shapes(i,:)=sin((HPm_all{lengthindex}(i)-0.5)*pi*x_length/HPlengths(lengthindex)).*sin(pi*x_length/HPlengths(lengthindex)/2);
             end

--- a/interface/commandbar.m
+++ b/interface/commandbar.m
@@ -450,16 +450,19 @@ p3a = uitoggletool(t,'TooltipString','Pan',...
                 'commandbar_cb(51);']);
                 load pan;
                 p3a.CData = cdata;
+				pan off
 p3b = uitoggletool(t,'TooltipString','Zoom',...
                 'ClickedCallback',[...
                 'commandbar_cb(52);']);
                 load zoom
                 p3b.CData = zoomCData;
+				zoom off
 p3c = uitoggletool(t,'TooltipString','Rotate',...
                 'ClickedCallback',[...
                 'commandbar_cb(53);']);
                 load rotate
                 p3c.CData = cdata;
+				rotate3d off
 % %CUFSM
 spacer = uipushtool(t);
                 [img,map] = imread('blank.png','BackgroundColor',[0.94 0.94 0.94]);

--- a/plotters/dispshp2.m
+++ b/plotters/dispshp2.m
@@ -84,7 +84,7 @@ modeDisp=reshape(mode,4*nNd,[]);
 %dispNorm_lgFuncs=vecnorm(modeDisp); %function "vecnorm" is not supported by Matlab2016
 dispNorm_lgFuncs=zeros(1,size(modeDisp,2));
 for iFunc=1:size(modeDisp,2)
-	dispNorm_lgFuncs=norm(modeDisp(:,iFunc));
+	dispNorm_lgFuncs(iFunc)=norm(modeDisp(:,iFunc));
 end
 
 %if the deformation corresponding to a longi-function is very small (let's say smaller than 1/50 of the largest one), we don't need to care much about this small sub-deformation when plotting


### PR DESCRIPTION
1 3D deformation with multiple longitudinal terms is not segmented enough longitudinally. Fixed. 2 "Longitudinal Shape Function" of general "C-F" boundary Condition not all displayed. Fixed. 3 Status of "Pan", "Zoom", and "Rotate" not correctly initialized after switching pages. Fixed.