### PR TITLE
Adjust GUI generating order in Post-Process page

### DIFF
--- a/interface/compareout.m
+++ b/interface/compareout.m
@@ -746,6 +746,8 @@ btn_cfsmhelp=uicontrol(fig,...
     'Callback',[...
     'cufsmhelp(22);']);
 
+%%Plot initial shapes and render into axes
+%-----------------------------------------
 %Plot the mode shape as a start
 mode=shapes{lengthindex}(:,modeindex);
 undefv=get(ctrlCompUndef,'Value');
@@ -790,4 +792,5 @@ else
     set(hlegend,'Location','best');
     hold off    
 end
+
 end

--- a/interface/compareout.m
+++ b/interface/compareout.m
@@ -18,7 +18,7 @@ global ed_m ed_neigs solutiontype togglesignature togglegensolution popup_BC tog
 %output from cFSM
 global toggleglobal toggledist togglelocal toggleother ed_global ed_dist ed_local ed_other NatBasis ModalBasis toggleCouple popup_load axesoutofplane axesinplane axes3d lengthindex modeindex spaceindex longitermindex b_v_view modename spacename check_3D cutface_edit len_cur mode_cur space_cur longterm_cur modes SurfPos scale twod threed undef scale_tex
 %output from compareout
-global pathname filename pathnamecell filenamecell propcell nodecell elemcell lengthscell curvecell clascell shapescell springscell constraintscell GBTconcell solutiontypecell BCcell m_allcell filedisplay files fileindex modes modeindex mmodes mmodeindex lengthindex axescurve togglelfvsmode togglelfvslength curveoption ifcheck3d minopt logopt threed undef axes2dshapelarge togglemin togglelog modestoplot_tex filetoplot_tex modestoplot_title filetoplot_title checkpatch len_plot lf_plot mode_plot SurfPos cutsurf_tex filename_plot len_cur scale_tex mode_cur mmode_cur file_cur xmin_tex xmax_tex ymin_tex ymax_tex filetoplot_tex screen popup_plot filename_title2 clasopt popup_classify times_classified toggleclassify classification_results plength_cur pfile_cur togglepfiles toggleplength mlengthindex mfileindex axespart_title axes2dshape axes3dshape axesparticipation axescurvemode  modedisplay modestoplot_tex
+global pathname filename pathnamecell filenamecell propcell nodecell elemcell lengthscell curvecell clascell shapescell springscell constraintscell GBTconcell solutiontypecell BCcell m_allcell filedisplay files fileindex modes modeindex mmodes mmodeindex lengthindex axescurve togglelfvsmode togglelfvslength curveoption ifcheck3d minopt logopt threed ctrlCompUndef axes2dshapelarge togglemin togglelog modestoplot_tex filetoplot_tex modestoplot_title filetoplot_title checkpatch len_plot lf_plot mode_plot SurfPos cutsurf_tex filename_plot len_cur scale_tex mode_cur mmode_cur file_cur xmin_tex xmax_tex ymin_tex ymax_tex filetoplot_tex screen popup_plot filename_title2 clasopt popup_classify times_classified toggleclassify classification_results plength_cur pfile_cur togglepfiles toggleplength mlengthindex mfileindex axespart_title axes2dshape axes3dshape axesparticipation axescurvemode  modedisplay modestoplot_tex
     %by Sheng Jin from compareout
     global toggle_3D popup_3dItem popup_3dData popup_3dStyle
 
@@ -136,26 +136,17 @@ modeindex=1;
 clasopt=0;
 logopt=1;
 minopt=1;
-xmin=min(lengths)*10/11;
-ymin=0;
-xmax=max(lengths)*11/10;
-for j=1:max(size(curve));
-    curve_sign(j,1)=curve{j}(modeindex,1);
-    curve_sign(j,2)=curve{j}(modeindex,2);
-end
-ymax=min([max(curve_sign(:,2)),3*median(curve_sign(curve_sign(:,2)>0,2))]);
 
 modes=(1:1:length(curve{lengthindex}(:,2)));
 modedisplay=1;
 filedisplay=files;
 
 threed=1; %Jan 2024, 3D plotter is fast now, start out with it on.
-undef=1;
+undefv=1;
 scale=1;
 SurfPos=1/2;
 curveoption=1;
 ifcheck3d=1;
-ifpatch=0;
 m_a=m_all{lengthindex};
 
 if exist('springs')
@@ -163,33 +154,15 @@ else
     springs=0;
 end
 %
-%Plot the first mode shape as a start
-mode=shapes{lengthindex}(:,modeindex);
-if threed==1
-    dispshap(undef,node,elem,mode,axes2dshape,scale,springs,m_a,BC,SurfPos);
-
-	if undef
-		Item3D=3;%Deformed shape & undeformed mesh
-	else
-		Item3D=1;%Deformed shape only
-	end
-	Data3D=1;%Vector sum of Displacement
-	ifColorBar=1;%draw color bar
-    ifSurface=1; %draw in surface style
-    dispshp2(lengths(lengthindex),node,elem,mode,axes3dshape,scale,m_all{lengthindex},BC,0,Item3D,Data3D,ifSurface,ifColorBar);
-    %dispshp2(undef,lengths(lengthindex),node,elem,mode,axes3dshape,scale,m_a,BC,ifpatch);
-else
-    dispshap(undef,node,elem,mode,axes2dshapelarge,scale,springs,m_a,BC,SurfPos);
-end
-%Plot the buckling curve as a start
 if length(lengths)==1
     curveoption=2;
 end
+
 if curveoption==1
     xmin=min(lengths)*10/11;
     ymin=0;
     xmax=max(lengths)*11/10;
-    for j=1:max(size(curve));
+    for j=1:max(size(curve))
         curve_sign(j,1)=curve{j}(modeindex,1);
         curve_sign(j,2)=curve{j}(modeindex,2);
     end
@@ -199,36 +172,6 @@ elseif curveoption==2
     ymin=0;
     xmax=length(curve{lengthindex}(:,2));
     ymax=min([max(curve{lengthindex}(:,2)),3*median(curve{lengthindex}(:,2))]);
-end
-
-if curveoption==1
-    picpoint=[curve{lengthindex}(modeindex,1) curve{lengthindex}(modeindex,2)];
-    thecurve3(curvecell,filenamecell,clascell,filedisplay,minopt,logopt,clasopt,axescurve,xmin,xmax,ymin,ymax,modedisplay,fileindex,modeindex,picpoint)
-else
-    axes(axescurve);
-    cla reset, axis off
-    %
-    set(axescurvemode,'visible','on');
-    set(axesparticipation,'visible','on');
-    
-    %plot the load factor vs mode number curve
-    picpoint=[modes(modeindex) curve{lengthindex}(modeindex,2)];
-    thecurve3mode(curvecell,filenamecell,clascell,fileindex,minopt,logopt,clasopt,axescurvemode,xmin,xmax,ymin,ymax,fileindex,lengthindex,picpoint);
-    
-    %plot the participation vs longitudinal terms
-    mode=shapes{lengthindex}(:,modeindex);
-    nnodes=length(node(:,1));
-    m_a=m_all{lengthindex};
-    [d_part]=longtermpart(nnodes,mode,m_a);
-    axes(axesparticipation)
-    cla
-    bar(m_a,d_part);hold on
-    xlabel('m, longitudinal term');hold on;
-    ylabel('Participation');hold on;
-    legendstring=[filenamecell{fileindex},', length = ',num2str(lengths(lengthindex)), ', mode = ', num2str(modeindex)];
-    hlegend=legend(legendstring);hold on
-    set(hlegend,'Location','best');
-    hold off    
 end
 
 %%GUI CONTROLS FOLLOW
@@ -317,11 +260,11 @@ cutsurf_tex=uicontrol(fig,...
     'String',num2str(SurfPos),...
     'Callback','compareout_cb(1)');
 
-undef=uicontrol(fig,...
+ctrlCompUndef=uicontrol(fig,...
     'Style','checkbox','units','normalized',...
     'Position',[0.21 0.86 0.05 0.025],...
     'String','Undef.',...
-    'Value',1,...
+    'Value',undefv,...
     'Callback',[...
     'compareout_cb(1);']);
 %% length, mode, and file
@@ -802,4 +745,49 @@ btn_cfsmhelp=uicontrol(fig,...
     'String','?',...
     'Callback',[...
     'cufsmhelp(22);']);
+
+%Plot the mode shape as a start
+mode=shapes{lengthindex}(:,modeindex);
+undefv=get(ctrlCompUndef,'Value');
+if threed==1
+	dispshap(undefv,node,elem,mode,axes2dshape,scale,springs,m_a,BC,SurfPos);
+	
+	Item3D=get(popup_3dItem,'Value');
+	Data3D=get(popup_3dData,'Value');
+	ifSurface=get(popup_3dStyle,'Value');
+	ifColorBar=1;%draw color bar
+	dispshp2(lengths(lengthindex),node,elem,mode,axes3dshape,scale,m_all{lengthindex},BC,0,Item3D,Data3D,ifSurface,ifColorBar);
+else
+    dispshap(undefv,node,elem,mode,axes2dshapelarge,scale,springs,m_a,BC,SurfPos);
+end
+%Plot the buckling curve as a start
+if curveoption==1
+    picpoint=[curve{lengthindex}(modeindex,1) curve{lengthindex}(modeindex,2)];
+    thecurve3(curvecell,filenamecell,clascell,filedisplay,minopt,logopt,clasopt,axescurve,xmin,xmax,ymin,ymax,modedisplay,fileindex,modeindex,picpoint)
+else
+    axes(axescurve);
+    cla reset, axis off
+    %
+    set(axescurvemode,'visible','on');
+    set(axesparticipation,'visible','on');
+    
+    %plot the load factor vs mode number curve
+    picpoint=[modes(modeindex) curve{lengthindex}(modeindex,2)];
+    thecurve3mode(curvecell,filenamecell,clascell,fileindex,minopt,logopt,clasopt,axescurvemode,xmin,xmax,ymin,ymax,fileindex,lengthindex,picpoint);
+    
+    %plot the participation vs longitudinal terms
+    mode=shapes{lengthindex}(:,modeindex);
+    nnodes=length(node(:,1));
+    m_a=m_all{lengthindex};
+    [d_part]=longtermpart(nnodes,mode,m_a);
+    axes(axesparticipation)
+    cla
+    bar(m_a,d_part);hold on
+    xlabel('m, longitudinal term');hold on;
+    ylabel('Participation');hold on;
+    legendstring=[filenamecell{fileindex},', length = ',num2str(lengths(lengthindex)), ', mode = ', num2str(modeindex)];
+    hlegend=legend(legendstring);hold on
+    set(hlegend,'Location','best');
+    hold off    
+end
 end

--- a/interface/compareout_cb.m
+++ b/interface/compareout_cb.m
@@ -18,7 +18,7 @@ global ed_m ed_neigs solutiontype togglesignature togglegensolution popup_BC tog
 %output from cFSM
 global toggleglobal toggledist togglelocal toggleother ed_global ed_dist ed_local ed_other NatBasis ModalBasis toggleCouple popup_load axesoutofplane axesinplane axes3d lengthindex modeindex spaceindex longitermindex b_v_view modename spacename check_3D cutface_edit len_cur mode_cur space_cur longterm_cur modes SurfPos scale twod threed undef scale_tex
 %output from compareout
-global pathname filename pathnamecell filenamecell propcell nodecell elemcell lengthscell curvecell clascell shapescell springscell constraintscell GBTconcell solutiontypecell BCcell m_allcell filedisplay files fileindex modes modeindex mmodes mmodeindex lengthindex axescurve togglelfvsmode togglelfvslength curveoption ifcheck3d minopt logopt threed undef axes2dshapelarge togglemin togglelog modestoplot_tex filetoplot_tex modestoplot_title filetoplot_title checkpatch len_plot lf_plot mode_plot SurfPos cutsurf_tex filename_plot len_cur scale_tex mode_cur mmode_cur file_cur xmin_tex xmax_tex ymin_tex ymax_tex filetoplot_tex screen popup_plot filename_title2 clasopt popup_classify times_classified toggleclassify classification_results plength_cur pfile_cur togglepfiles toggleplength mlengthindex mfileindex axespart_title axes2dshape axes3dshape axesparticipation axescurvemode  modedisplay modestoplot_tex
+global pathname filename pathnamecell filenamecell propcell nodecell elemcell lengthscell curvecell clascell shapescell springscell constraintscell GBTconcell solutiontypecell BCcell m_allcell filedisplay files fileindex modes modeindex mmodes mmodeindex lengthindex axescurve togglelfvsmode togglelfvslength curveoption ifcheck3d minopt logopt threed ctrlCompUndef axes2dshapelarge togglemin togglelog modestoplot_tex filetoplot_tex modestoplot_title filetoplot_title checkpatch len_plot lf_plot mode_plot SurfPos cutsurf_tex filename_plot len_cur scale_tex mode_cur mmode_cur file_cur xmin_tex xmax_tex ymin_tex ymax_tex filetoplot_tex screen popup_plot filename_title2 clasopt popup_classify times_classified toggleclassify classification_results plength_cur pfile_cur togglepfiles toggleplength mlengthindex mfileindex axespart_title axes2dshape axes3dshape axesparticipation axescurvemode  modedisplay modestoplot_tex
 %by Sheng Jin
 global toggle_3D popup_3dItem popup_3dData popup_3dStyle
 %
@@ -35,7 +35,7 @@ val = get(popup_plot,'Value');
 if val == 1
     %in-plane
 	scale=str2num(get(scale_tex,'String'));
-	undefv=get(undef,'Value');
+	undefv=get(ctrlCompUndef,'Value');
     SurfPos=str2num(get(cutsurf_tex,'String'));
     mode=shapes{lengthindex}(:,modeindex);
     if ifcheck3d==1
@@ -512,7 +512,7 @@ set(subfig,'position',[100 100 500 300])%
 set(subfig,'units','normalized')
 axescapture=axes('Units','normalized','Position',[0.01 0.09 0.97 0.85],'visible','off');
 scale=str2num(get(scale_tex,'String'));
-undefv=get(undef,'Value');
+undefv=get(ctrlCompUndef,'Value');
 SurfPos=str2num(get(cutsurf_tex,'String'));
 mode=shapes{lengthindex}(:,modeindex);
 


### PR DESCRIPTION
GUIs can be generated in a faster speed when mode shapes and curves haven't been displayed